### PR TITLE
Use forbid unsafe code on crate level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! A flexible client API framework as well as a set of API collections.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
 
 extern crate alloc;
 


### PR DESCRIPTION
This adds the forbid unsafe code attribute on crate level, which statically
ensures no usage of `unsafe` in the whole crate.